### PR TITLE
Allow installation on MacOS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if sys.platform == 'darwin':
 	os.environ["CPATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
 else:
 	platform_link_args = ['-Wl,--no-as-needed', "-lmkl_def"]
-	sdl_platform_link_args = ['lmkl_def']
+	sdl_platform_link_args = ['-Wl,--no-as-needed']
 
 
 if sdl:


### PR DESCRIPTION
I fixed a couple of issues which prevented easy installation of pawpyseed on MacOS X. To summarize these were:
- The OSX linker does not support the `--no-as-needed` argument. 
- Installing `mkl` on Mac does not provide `libmkl_def`
- The default clang/gcc installations do not support openmp. If you install a different compiler with openmp support it will not automatically have access to the c++ std library headers. A few OS releases ago, these were moved from `/usr/include/` to inside the Xcode application for some reason. I've therefore set the script to point to the standardized include directory.

A reliable recipe for install pawpyseed on MacOS X (tested in a fresh Conda environment) is as follows:

```bash
# 1. First install Xcode command line tools. You will most likely already have
#    these installed.
xcode-select --install

# 2. Use Conda to install mkl and a compiler that supports open-mp. 
#    Install conda here if you don't already have it: 
#    https://docs.conda.io/en/latest/miniconda.html
conda install clang mkl mkl-include cython

# 3. Install pawpyseed using the open-mp supported compiler.
CC=clang pip install pawpyseed
```


