### PR TITLE
Add options to Wavefunction.desymmetrized_copy()

### DIFF
--- a/pawpyseed/core/pawpyc.pxd
+++ b/pawpyseed/core/pawpyc.pxd
@@ -13,7 +13,8 @@ cdef class PWFPointer:
 
     @staticmethod
     cdef PWFPointer from_pointer_and_kpts(ppc.pswf_t* ptr,
-        structure, kpts, band_props, allkpts, weights)
+        structure, kpts, band_props, allkpts, weights, symprec,
+        time_reversal_symmetry)
 
 cdef class PseudoWavefunction:
 

--- a/pawpyseed/core/wavefunction.py
+++ b/pawpyseed/core/wavefunction.py
@@ -218,12 +218,11 @@ class Wavefunction(pawpyc.CWavefunction):
 		self.dim = np.array(dim, dtype=np.int32)
 		self.update_dimv(dim)
 
-	def desymmetrized_copy(self, allkpts = None, weights = None):
+	def desymmetrized_copy(self, allkpts=None, weights=None, symprec=None,
+							time_reversal_symmetry=True):
 		"""
 		Returns a copy of self with a k-point mesh that is not reduced
-		using crystal symmetry (time reversal symmetry is still used;
-		an option to not use time reversal symmetry will be added in
-		the future).
+		using crystal symmetry.
 
 		Arguments:
 			allkpts (optional, None): An optional k-point mesh to map
@@ -231,9 +230,17 @@ class Wavefunction(pawpyc.CWavefunction):
 			weights (optional, None): If allkpts is not None, weights
 				should contain the k-point weights of each k-point,
 				with the sum normalized to 1.
+			symprec: Symmetry precision to use when determining the space group.
+				If None, the symmetry precision used to generate the
+				Wavefunction will be used (the default).
+			time_reversal_symmetry: Whether time reversal symmetry is used.
 		"""
-		pwf = self._desymmetrized_pwf(self.structure, self.band_props, allkpts, weights)
-		new_wf = Wavefunction(self.structure, pwf, self.cr, self.dim)
+		if not symprec:
+			symprec = self.symprec
+
+		pwf = self._desymmetrized_pwf(self.structure, self.band_props, allkpts, weights,
+										symprec, time_reversal_symmetry)
+		new_wf = Wavefunction(self.structure, pwf, self.cr, self.dim, symprec=symprec)
 		return new_wf
 
 	@staticmethod

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if sys.platform == 'darwin':
 	os.environ["CPATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
 else:
 	platform_link_args = ['-Wl,--no-as-needed', "-lmkl_def"]
-	sdl_platform_link_args = ['lmkl_def']
+	sdl_platform_link_args = ['-Wl,--no-as-needed']
 
 
 if sdl:


### PR DESCRIPTION
Added options to control the symmetry precision and whether time reversal symmetry is used in `Wavefunction.desymmetrized_copy`.

This PR is based on the GitHub branch in #7, hence it also includes those commits. 

Fixes #6