### PR TITLE
Cleaner setup and NCL normalization fix

### DIFF
--- a/pawpyseed/analysis/defect_composition.py
+++ b/pawpyseed/analysis/defect_composition.py
@@ -7,7 +7,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import yaml
-from pymatgen import Spin
+from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.vasp.inputs import Poscar
 from pymatgen.io.vasp.outputs import Vasprun
 

--- a/pawpyseed/core/density.c
+++ b/pawpyseed/core/density.c
@@ -233,12 +233,9 @@ void realspace_state(double complex *x, int BAND_NUM, int KPOINT_NUM,
                      pswf_t *wf, int *fftg, int *labels, double *coords) {
 
   ppot_t *pps = wf->pps;
-  // double complex* x = mkl_calloc(fftg[0]*fftg[1]*fftg[2], sizeof(double
-  // complex), 64); printf("START FT\n");
   fft3d(x, wf->G_bounds, wf->lattice, wf->kpts[KPOINT_NUM]->k,
         wf->kpts[KPOINT_NUM]->Gs, wf->kpts[KPOINT_NUM]->bands[BAND_NUM]->Cs,
         wf->kpts[KPOINT_NUM]->bands[BAND_NUM]->num_waves, fftg);
-  // printf("FINISH FT\n");
   double *lattice = wf->lattice;
   double vol = determinant(lattice);
   for (int i = 0; i < fftg[0]; i++) {
@@ -304,12 +301,6 @@ void realspace_state(double complex *x, int BAND_NUM, int KPOINT_NUM,
                               pp.wave_gridsize, pros.ls[n], pros.ms[n],
                               testcoord) *
                   pros.overlaps[n] * cexp(2 * PI * I * phase);
-
-              //	wave_value(pp.funcs[pros.ns[n]],
-              //	pp.wave_gridsize, pp.wave_grid,
-              //	pros.ms[n], coords+3*p, frac, lattice)
-              //	* pros.overlaps[n] * cexp(2*PI*I*phase);
-              //	* Ylm(thetaphi[0], thetaphi[1]);
             }
           }
         }
@@ -338,8 +329,7 @@ void ncl_realspace_state(double complex *x, int BAND_NUM, int KPOINT_NUM,
                          pswf_t *wf, int *fftg, int *labels, double *coords) {
 
   ppot_t *pps = wf->pps;
-  double complex *xup =
-      x; // mkl_calloc(2*fftg[0]*fftg[1]*fftg[2], sizeof(double complex), 64);
+  double complex *xup = x;
   double complex *xdown = x + fftg[0] * fftg[1] * fftg[2];
   int num_waves = wf->kpts[KPOINT_NUM]->bands[BAND_NUM]->num_waves / 2;
   fft3d(xup, wf->G_bounds, wf->lattice, wf->kpts[KPOINT_NUM]->k,
@@ -411,14 +401,16 @@ void ncl_realspace_state(double complex *x, int BAND_NUM, int KPOINT_NUM,
             phase = dot(phasecoord, wf->kpts[KPOINT_NUM]->k);
             for (int n = 0; n < up_pros.total_projs; n++) {
               xup[ii * fftg[1] * fftg[2] + jj * fftg[2] + kk] +=
-                  wave_value(pp.funcs[up_pros.ns[n]], pp.wave_gridsize,
-                             pp.wave_grid, up_pros.ms[n], coords + 3 * p, frac,
-                             lattice) *
+                  wave_value2(pp.wave_grid, pp.funcs[up_pros.ns[n]].diffwave,
+                              pp.funcs[up_pros.ns[n]].diffwave_spline,
+                              pp.wave_gridsize, up_pros.ls[n], up_pros.ms[n],
+                              testcoord) *
                   up_pros.overlaps[n] * cexp(2 * PI * I * phase);
               xdown[ii * fftg[1] * fftg[2] + jj * fftg[2] + kk] +=
-                  wave_value(pp.funcs[down_pros.ns[n]], pp.wave_gridsize,
-                             pp.wave_grid, down_pros.ms[n], coords + 3 * p,
-                             frac, lattice) *
+                  wave_value2(pp.wave_grid, pp.funcs[down_pros.ns[n]].diffwave,
+                              pp.funcs[down_pros.ns[n]].diffwave_spline,
+                              pp.wave_gridsize, down_pros.ls[n], down_pros.ms[n],
+                              testcoord) *
                   down_pros.overlaps[n] * cexp(2 * PI * I * phase);
             }
           }

--- a/pawpyseed/core/density.c
+++ b/pawpyseed/core/density.c
@@ -409,8 +409,8 @@ void ncl_realspace_state(double complex *x, int BAND_NUM, int KPOINT_NUM,
               xdown[ii * fftg[1] * fftg[2] + jj * fftg[2] + kk] +=
                   wave_value2(pp.wave_grid, pp.funcs[down_pros.ns[n]].diffwave,
                               pp.funcs[down_pros.ns[n]].diffwave_spline,
-                              pp.wave_gridsize, down_pros.ls[n], down_pros.ms[n],
-                              testcoord) *
+                              pp.wave_gridsize, down_pros.ls[n],
+                              down_pros.ms[n], testcoord) *
                   down_pros.overlaps[n] * cexp(2 * PI * I * phase);
             }
           }

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 
 print("SDL!!!", sdl)
 if sdl:
-    libs.extend(["mkl_rt", 'iomp5'])
+    libs.extend(["mkl_rt", "iomp5"])
 else:
     interfacelib = "mkl_intel_lp64"
     if threaded_mkl:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ if sys.platform == "darwin":
 else:
     link_args = ["-Wl,--no-as-needed"]
 
-print("SDL!!!", sdl)
 if sdl:
     libs.extend(["mkl_rt", "iomp5"])
 else:

--- a/setup.py
+++ b/setup.py
@@ -61,34 +61,30 @@ sdl = config["mkl"].getboolean("sdl")
 omp_loops = config["threading"].getboolean("omp_loops")
 threaded_mkl = config["threading"].getboolean("threaded_mkl")
 
+libs = []
 if sys.platform == "darwin":
     # platform_link_args = ['-lmkl_avx512']
-    platform_link_args = []
-    sdl_platform_link_args = []
+    link_args = []
     os.environ[
         "CPATH"
     ] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
 else:
-    platform_link_args = ["-Wl,--no-as-needed", "-lmkl_def"]
-    sdl_platform_link_args = ["-Wl,--no-as-needed"]
-
+    link_args = ["-Wl,--no-as-needed"]
 
 if sdl:
-    link_args = sdl_platform_link_args + "-lmkl_rt -liomp5 -lpthread -lm -ldl".split()
+    libs.extend(["mkl_rt", "iomp5"])
 else:
-    interfacelib = "-lmkl_intel_lp64"
+    interfacelib = "mkl_intel_lp64"
     if threaded_mkl:
-        threadlib = "-lmkl_intel_thread"
-        omplib = "-liomp5"
+        threadlib = "mkl_intel_thread"
+        omplib = "iomp5"
     else:
-        threadlib = "-lmkl_sequential"
-        omplib = ""
-    link_args = "{} {} -lmkl_core {} -lpthread -lm -ldl".format(
-        interfacelib,
-        threadlib,
-        omplib,
-    )
-    link_args = platform_link_args + link_args.split()
+        threadlib = "mkl_sequential"
+        omplib = None
+    libs.extend([interfacelib, threadlib, "mkl_core"])
+    if omplib is not None:
+        libs.append(omplib)
+libs.extend(["pthread", "m", "dl"])
 
 # SET OTHER COMPILER ARGS
 extra_args = "-std=c11 -fPIC -Wall".split()
@@ -97,24 +93,68 @@ if omp_loops:
 
 # ADD ADDITIONAL MKL LIBRARIES IF FOUND IN CONFIG
 lib_dirs = []
-inc_dirs = ["pawpyseed/core", np.get_include()]
+include_dirs = ["pawpyseed/core", np.get_include()]
 if "root" in config["mkl"]:
     root_dirs = config["mkl"]["root"].split(":")
     for r in root_dirs:
         lib_dirs.append(os.path.join(r, "lib/intel64"))
         lib_dirs.append(os.path.join(r, "lib"))
-        inc_dirs.append(os.path.join(r, "include"))
+        include_dirs.append(os.path.join(r, "include"))
 if "extra_libs" in config["compiler"]:
     extra_dirs = config["compiler"]["extra_libs"].split(":")
     for d in extra_dirs:
         lib_dirs.append(d)
+
+macros = [
+    ("MKL_Complex16", "double complex"),
+    ("MKL_Complex8", "float complex"),
+]
+cython_macros = {}  # Cython macros in .pyx files
+comp_direct = {  # compiler_directives
+    "language_level": 3,  # use python 3
+    "embedsignature": True,  # write function signature in doc-strings
+}
+# using path search of tenpy: https://github.com/tenpy/tenpy/blob/main/setup.py
+HAVE_MKL = 0
+MKL_DIR = os.getenv("MKL_DIR", os.getenv("MKLROOT", os.getenv("MKL_HOME", "")))
+if MKL_DIR:
+    include_dirs.append(os.path.join(MKL_DIR, "include"))
+    lib_dirs.append(os.path.join(MKL_DIR, "lib", "intel64"))
+    HAVE_MKL = 1
+CONDA_PREFIX = os.getenv("CONDA_PREFIX")
+if CONDA_PREFIX:
+    include_dirs.append(os.path.join(CONDA_PREFIX, "include"))
+    lib_dirs.append(os.path.join(CONDA_PREFIX, "lib"))
+    if not HAVE_MKL:
+        # check whether mkl-devel is installed
+        HAVE_MKL = int(os.path.exists(os.path.join(CONDA_PREFIX, "include", "mkl.h")))
+PYTHON_BASE = sys.base_prefix
+if PYTHON_BASE != CONDA_PREFIX:
+    nclude_dirs.append(os.path.join(PYTHON_BASE, "include"))
+    lib_dirs.append(os.path.join(PYTHON_BASE, "lib"))
+    if not HAVE_MKL:
+        # check whether mkl-devel is installed
+        HAVE_MKL = int(os.path.exists(os.path.join(PYTHON_BASE, "include", "mkl.h")))
+HAVE_MKL = int(os.getenv("HAVE_MKL", HAVE_MKL))
+cython_macros["HAVE_MKL"] = HAVE_MKL
+if HAVE_MKL:
+    if os.getenv("MKL_INTERFACE_LAYER", "LP64").startswith("ILP64"):
+        macros.append(("MKL_ILP64", None))
+        cython_macros["MKL_INTERFACE_LAYER"] = 1
+    else:
+        cython_macros["MKL_INTERFACE_LAYER"] = 0
+else:
+    raise PawpyBuildError(
+        "Must have MKL installed to build pawpyseed. Please run 'pip install mkl-devel'"
+    )
+
 
 # SET UP COMPILE/LINK ARGS AND THREADING
 cfiles = [f + ".c" for f in srcfiles]
 ext_files = cfiles
 ext_files = ["pawpyseed/core/" + f for f in ext_files]
 if DEBUG:
-    inc_dirs.append("pawpyseed/core/tests")
+    include_dirs.append("pawpyseed/core/tests")
 rt_lib_dirs = lib_dirs[:]
 
 if not DEBUG:
@@ -126,15 +166,13 @@ extensions = [
     Extension(
         "pawpyseed.core.pawpyc",
         ext_files + ["pawpyseed/core/pawpyc.pyx"],
-        define_macros=[
-            ("MKL_Complex16", "double complex"),
-            ("MKL_Complex8", "float complex"),
-        ],
+        define_macros=macros,
+        libraries=libs,
         library_dirs=lib_dirs,
         extra_link_args=extra_args + link_args,
         extra_compile_args=extra_args,
         runtime_library_dirs=rt_lib_dirs,
-        include_dirs=inc_dirs,
+        include_dirs=include_dirs,
     )
 ]
 
@@ -144,15 +182,13 @@ if DEBUG:
             "pawpyseed.core.tests.testc",
             ["pawpyseed/core/tests/testc.pyx", "pawpyseed/core/tests/tests.c"]
             + ext_files,
-            define_macros=[
-                ("MKL_Complex16", "double complex"),
-                ("MKL_Complex8", "float complex"),
-            ],
+            define_macros=macros,
+            libraries=libs,
             library_dirs=lib_dirs,
             extra_link_args=extra_args + link_args,
             extra_compile_args=extra_args,
             runtime_library_dirs=rt_lib_dirs,
-            include_dirs=inc_dirs,
+            include_dirs=include_dirs,
         )
     )
 
@@ -191,6 +227,8 @@ setup(
     ext_modules=cythonize(
         extensions,
         include_path=[os.path.join(os.path.abspath(__file__), "pawpyseed/core")],
+        compile_time_env=cython_macros,
+        compiler_directives=comp_direct,
     ),
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ else:
     link_args = ["-Wl,--no-as-needed"]
 
 if sdl:
-    libs.extend(["mkl_rt", "iomp5"])
+    libs.extend(["mkl_rt"])
 else:
     interfacelib = "mkl_intel_lp64"
     if threaded_mkl:

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,19 @@ import os
 import sys
 
 import numpy as np
-from Cython.Build import cythonize
 from setuptools import Extension, setup
 
 
 class PawpyBuildError(Exception):
     pass
+
+
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    raise ImportError(
+        "Need Cython>=0.29.21 to build pawpyseed. Please run 'pip install cython'"
+    )
 
 
 with codecs.open("README.md", "r", encoding="utf8") as fh:

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,9 @@ if sys.platform == "darwin":
 else:
     link_args = ["-Wl,--no-as-needed"]
 
+print("SDL!!!", sdl)
 if sdl:
-    libs.extend(["mkl_rt"])
+    libs.extend(["mkl_rt", 'iomp5'])
 else:
     interfacelib = "mkl_intel_lp64"
     if threaded_mkl:

--- a/site.cfg.default
+++ b/site.cfg.default
@@ -4,9 +4,8 @@
 # extra_libs = /usr/lib
 
 [mkl]
+sdl = True
 # root = ~/.local/lib:/usr/lib
-interface32 = True
-sdl = False
 
 [threading]
 omp_loops = True


### PR DESCRIPTION
For newer PAW datasets, in which the augmentation grid goes out to a large distance, a bug became apparent in the projection of NCL wavefunctions into realspace. This issue is fixed here.

In addition, the setup script is improved to look for MKL and exit in error if MKL is not found. The Single Dynamic Library (SDL) is also used by default now (matching numpy and scipy), which should make installation easier and the code more portable.